### PR TITLE
Fix alexhillc/AXPhotoViewer#28

### DIFF
--- a/Source/Classes/View Controllers/AXPhotosViewController.swift
+++ b/Source/Classes/View Controllers/AXPhotosViewController.swift
@@ -529,6 +529,7 @@ import FLAnimatedImage_tvOS
                                                    animated: animated,
                                                    completion: nil)
         self.loadPhotos(at: photoIndex)
+        self.currentPhotoIndex = photoIndex
     }
     
     // MARK: - Page VC Configuration


### PR DESCRIPTION
By assigning the new photoIndex to self.currentPhotoIndex, the following assertion and crash scenario is fixed:
1. Host app creates an `AXPhotosViewController` and calls `navigateToPhotoIndex(index, animated: false)` on it, where index > 0
2. Host app presents `AXPhotosViewController`
3. User does not swipe left or right, but just dismisses the photo view
4. Assertion "Unable to resolve some necessary properties in order to transition. [...]" fails, and on a non-debug build the app crashes.