### PR TITLE
Fix dismissing viewController with dismiss(animated:completion:) method

### DIFF
--- a/Example/iOS/Podfile.lock
+++ b/Example/iOS/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
-  - AXPhotoViewer/Core (1.7.0):
+  - AXPhotoViewer/Core (1.7.1):
     - AXStateButton (>= 1.1.3)
     - FLAnimatedImage (>= 1.0.0)
     - FLAnimatedImage-tvOS (>= 1.0.16)
-  - AXPhotoViewer/PINRemoteImage (1.7.0):
+  - AXPhotoViewer/PINRemoteImage (1.7.1):
     - AXPhotoViewer/Core
     - PINRemoteImage (~> 3.0.0-beta.9)
   - AXStateButton (1.1.4)
@@ -53,7 +53,7 @@ EXTERNAL SOURCES:
     :path: "../../AXPhotoViewer.podspec"
 
 SPEC CHECKSUMS:
-  AXPhotoViewer: 530af2fdd8eca4336f509c4c3463826b3f12a4c2
+  AXPhotoViewer: f4b021c6e43b0b9dbc7b30cf8b9a4f577d0c1f51
   AXStateButton: 6c515a433e37551505046429b5be04c12daa8c07
   DRPLoadingSpinner: 725e530bf4ebe2cc351b1fbc94d24fe8ac3300fd
   FLAnimatedImage: 4a0b56255d9b05f18b6dd7ee06871be5d3b89e31
@@ -64,4 +64,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 6f4a81711307afc468e5f3e553aeb2549b5e1280
 
-COCOAPODS: 1.6.1
+COCOAPODS: 1.7.5

--- a/Source/Classes/Transition Controller + Animators/AXPhotosTransitionController.swift
+++ b/Source/Classes/Transition Controller + Animators/AXPhotosTransitionController.swift
@@ -30,8 +30,8 @@ class AXPhotosTransitionController: NSObject, UIViewControllerTransitioningDeleg
     /// Custom animator for dismissal.
     fileprivate var dismissalAnimator: AXPhotosDismissalAnimator?
     
-    /// If this flag is `true`, the transition controller will ignore any user gestures and instead trigger an immediate dismissal.
-    var forceNonInteractiveDismissal = false
+    /// If this flag is `true`, the transition controller will use gestures to dismiss viewController interactively, otherwise dismissal will be immediate.
+    var forceInteractiveDismissal = false
 
     /// The transition configuration passed in at initialization. The controller uses this object to apply customization to the transition.
     let transitionInfo: AXTransitionInfo
@@ -123,7 +123,7 @@ class AXPhotosTransitionController: NSObject, UIViewControllerTransitioningDeleg
     }
     
     public func interactionControllerForDismissal(using animator: UIViewControllerAnimatedTransitioning) -> UIViewControllerInteractiveTransitioning? {
-        if !self.supportsInteractiveDismissal || self.forceNonInteractiveDismissal {
+        if !self.supportsInteractiveDismissal || !self.forceInteractiveDismissal {
             return nil
         }
         

--- a/Source/Classes/View Controllers/AXPhotosViewController.swift
+++ b/Source/Classes/View Controllers/AXPhotosViewController.swift
@@ -497,7 +497,7 @@ import FLAnimatedImage_tvOS
             let canceled = (self.view.window != nil)
             
             if canceled {
-                self.transitionController?.forceNonInteractiveDismissal = false
+                self.transitionController?.forceInteractiveDismissal = false
                 #if os(iOS)
                 self.panGestureRecognizer?.isEnabled = true
                 #endif
@@ -611,7 +611,7 @@ import FLAnimatedImage_tvOS
     #if os(iOS)
     @objc fileprivate func didPanWithGestureRecognizer(_ sender: UIPanGestureRecognizer) {
         if sender.state == .began {
-            self.transitionController?.forceNonInteractiveDismissal = false
+            self.transitionController?.forceInteractiveDismissal = true
             self.dismiss(animated: true, completion: nil)
         }
         
@@ -661,7 +661,7 @@ import FLAnimatedImage_tvOS
     }
     
     @objc public func closeAction(_ sender: UIBarButtonItem) {
-        self.transitionController?.forceNonInteractiveDismissal = true
+        self.transitionController?.forceInteractiveDismissal = false
         self.dismiss(animated: true)
     }
     #endif


### PR DESCRIPTION
I use your gallery in my app, it's very nice, but if found issue:
When you try to dismiss photoViewer calling dismiss(animated:completion:) from another class, app freezes. It's because transitionController has flag "forceNonInteractiveDismissal" set to false and "interactionControllerForDismissal" return dismissal animator, while it should return nil to perform non interactive dismissal correctly.

I renamed flag "forceNonInteractiveDismissal" to "forceInteractiveDismissal" and changed logic, so interaction dismissal begins with gesture recognizer, and default dismissal is now non interactive.