### PR TITLE
Fix warning: MobileCoreServices has been renamed. Use CoreServices instead.

### DIFF
--- a/AXPhotoViewer.podspec
+++ b/AXPhotoViewer.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
                        'Source/Extensions/*.{swift,h,m}',
                        'Source/Utilities/*.{swift,h,m}',
                        'Source/Integrations/SimpleNetworkIntegration.swift'
-    cs.frameworks    = 'MobileCoreServices', 'ImageIO', 'UIKit', 'QuartzCore'
+    cs.frameworks    = 'ImageIO', 'UIKit', 'QuartzCore'
   end
 
   s.subspec 'SDWebImage' do |ss|


### PR DESCRIPTION
Close #78

If our library was installed via CocoaPods, Xcode 11.4 will issue the warning "MobileCoreServices has been renamed. Use CoreServices instead.".

![image](https://user-images.githubusercontent.com/526008/77892980-eecffd80-72a5-11ea-891b-78acd78d4b7c.png)

How to fix: Do not explicitly link `MobileCoreServices.framework` in the CocoaPods generated project, by deleting `MobileCoreServices` from the `spec.frameworks` attribute in our podspec file.

More info: https://github.com/AFNetworking/AFNetworking/pull/4532
