### PR TITLE
Moving resources to resource bundle

### DIFF
--- a/AXPhotoViewer.podspec
+++ b/AXPhotoViewer.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name            = "AXPhotoViewer"
-  s.version         = "1.7.1"
+  s.version         = "1.7.2"
   s.license         = { :type  => 'MIT', :file => 'LICENSE.md' }
   s.summary         = "An iOS/tvOS photo gallery viewer, useful for viewing a large number of photos."
   s.homepage        = "https://github.com/alexhillc/AXPhotoViewer"
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
     cs.ios.dependency  'AXStateButton', '>= 1.1.3'
     cs.ios.dependency  'FLAnimatedImage', '>= 1.0.0'
     cs.tvos.dependency 'FLAnimatedImage-tvOS', '>= 1.0.16'
-    cs.resources     = 'Assets/*.{xcassets}'
+    s.resource_bundle = { 'AXPhotoViewerResources' => ['Assets/*.{xcassets}'] }
     cs.source_files  = 'Source/*.{swift,h,m}',
                        'Source/Classes/**/*.{swift,h,m}',
                        'Source/Protocols/*.{swift,h,m}',

--- a/AXPhotoViewer.podspec
+++ b/AXPhotoViewer.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
     cs.ios.dependency  'AXStateButton', '>= 1.1.3'
     cs.ios.dependency  'FLAnimatedImage', '>= 1.0.0'
     cs.tvos.dependency 'FLAnimatedImage-tvOS', '>= 1.0.16'
-    s.resource_bundle = { 'AXPhotoViewerResources' => ['Assets/*.{xcassets}'] }
+    cs.resource_bundle = { 'AXPhotoViewerResources' => ['Assets/*.{xcassets}'] }
     cs.source_files  = 'Source/*.{swift,h,m}',
                        'Source/Classes/**/*.{swift,h,m}',
                        'Source/Protocols/*.{swift,h,m}',

--- a/Source/AXBundle.swift
+++ b/Source/AXBundle.swift
@@ -11,4 +11,11 @@ struct AXBundle {
         return Bundle(for: AXPhotosViewController.self)
     }
 
+    static var resourcesBundle: Bundle? {
+        
+        let bundle = AXBundle.frameworkBundle
+        guard let path = bundle.path(forResource: "AXPhotoViewerResources", ofType: "bundle") else { return nil }
+        
+        return Bundle(path: path)
+    }
 }

--- a/Source/Classes/Views/AXLoadingView.swift
+++ b/Source/Classes/Views/AXLoadingView.swift
@@ -51,7 +51,7 @@
     /// The image to show in the `errorImageView` when displaying an error.
     @objc open var errorImage: UIImage? {
         get {
-            return UIImage(named: "axphotoviewer-error", in: AXBundle.frameworkBundle, compatibleWith: nil)
+            return UIImage(named: "axphotoviewer-error", in: AXBundle.resourcesBundle, compatibleWith: nil)
         }
     }
     

--- a/Source/Extensions/FLAnimatedImageView+AXExtensions.h
+++ b/Source/Extensions/FLAnimatedImageView+AXExtensions.h
@@ -7,9 +7,9 @@
 //
 
 #if TARGET_OS_IOS
-@import FLAnimatedImage.FLAnimatedImageView;
+@import FLAnimatedImage;
 #elif TARGET_OS_TV
-@import FLAnimatedImage_tvOS.FLAnimatedImageView;
+@import FLAnimatedImage_tvOS;
 #endif
 
 @interface FLAnimatedImageView (AXExtensions)


### PR DESCRIPTION
This fixes build errors on new build system.
Currently only this pod in our app is using `resources` rather than `resources_bundle`.
These changes will allow us to remove `:disable_input_output_paths => true` from Podfile.
See this issue - https://github.com/CocoaPods/CocoaPods/issues/8122
